### PR TITLE
Shorten the ternary operator

### DIFF
--- a/src/Decomposer.php
+++ b/src/Decomposer.php
@@ -252,7 +252,7 @@ class Decomposer
 
     private static function checkSslIsInstalled()
     {
-        return (!empty($_SERVER['HTTPS']) && $_SERVER['HTTPS'] != 'off') ? true : false;
+        return (!empty($_SERVER['HTTPS']) && $_SERVER['HTTPS'] != 'off');
     }
 
     /**


### PR DESCRIPTION
I have shortened the ternary operator because it will return true or false in any way.